### PR TITLE
Fix cookie reset in footer

### DIFF
--- a/src/app/components/Footer.js
+++ b/src/app/components/Footer.js
@@ -4,10 +4,11 @@ import Link from 'next/link';
 import { FaInstagram, FaLinkedin, FaEnvelope } from 'react-icons/fa';
 
 export default function Footer() {
-const handleResetCookies = () => {
-  localStorage.removeItem('cookie-accepted');
-  window.location.reload();
-};
+  const handleResetCookies = () => {
+    // Align with CookieConsent localStorage key
+    localStorage.removeItem('cookieConsent');
+    window.location.reload();
+  };
 
 
   return (


### PR DESCRIPTION
## Summary
- align cookie reset key used in Footer.js with CookieConsent component

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f8245b8f0832c98b5e9ba2e008f2e